### PR TITLE
Add `Gemfile` and change script location

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'jwt'
+gem 'openssl'

--- a/get-installation-token.rb
+++ b/get-installation-token.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 
 require 'openssl'
 require 'jwt'  # https://rubygems.org/gems/jwt


### PR DESCRIPTION
This adds a `Gemfile` to make the dependencies explicit and allow them to be added by bundler.

Also changes the executable to `/usr/bin/env ruby` to select the user's preferred interpreter. Catalina doesn't have writable gem folders, and `/usr/bin/ruby` will only use the system gems. This works with rbenv, and likely asdf or a homebrew ruby. 
